### PR TITLE
feat add symbolic link to ssl certs

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,8 +27,8 @@ server {
 
     server_name api-staging.onlypawsapp.com;
 
-    ssl_certificate /etc/nginx/ssl/live/api-staging.onlypawsapp.com/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/api-staging.onlypawsapp.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/api-staging.onlypawsapp.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api-staging.onlypawsapp.com/privkey.pem;
 
     # SSL configuration improvements
     ssl_protocols TLSv1.2 TLSv1.3;

--- a/scripts/init-ssl.sh
+++ b/scripts/init-ssl.sh
@@ -87,5 +87,11 @@ docker compose -f docker/docker-compose.yml -f docker/$ENV/docker-compose.overri
     --agree-tos \
     --force-renewal" certbot
 
+# Add symbolic links to the latest certificates
+echo "### Creating symbolic links to the latest certificates ..."
+docker compose -f docker/docker-compose.yml -f docker/$ENV/docker-compose.override.yml run --rm --entrypoint "\
+    rm -f /etc/letsencrypt/live/${domains[0]} && \
+    ln -s /etc/letsencrypt/live/${domains[0]}* /etc/letsencrypt/live/${domains[0]}" certbot
+
 echo "### Reloading nginx ..."
 docker compose -f docker/docker-compose.yml -f docker/$ENV/docker-compose.override.yml exec nginx nginx -s reload 


### PR DESCRIPTION
Added symbolic link so that the nginx config can always find the newest certs. The new certs might have a numbered ending like -0001, so the symbolic link resolves that issue.