### PR TITLE
refactor: separate upstream config and remove duplicate mime types

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -11,6 +11,7 @@ RUN chmod -R 755 /vol/web
 # Copy both templates
 COPY ./templates/nginx.conf.template /etc/nginx/templates/
 COPY ./templates/init.conf.template /etc/nginx/templates/
+COPY ./templates/upstream.conf.template /etc/nginx/templates/
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 # Make the entrypoint script executable

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,10 +1,6 @@
 # prevent css, js files sent as text/plain objects
 include /etc/nginx/mime.types;
 
-upstream only-paws-app {
-    server only-paws-app:8000;
-}
-
 # HTTP server
 server {
     listen 80;
@@ -64,7 +60,6 @@ server {
 #    }
 #
 #    location /static/ {
-#        include mime.types;
 #        alias /vol/web/static/;
 #        expires 1y;
 #        add_header Cache-Control "public, no-transform";

--- a/nginx/templates/upstream.conf.template
+++ b/nginx/templates/upstream.conf.template
@@ -1,0 +1,3 @@
+upstream only-paws-app {
+    server only-paws-app:8000;
+} 


### PR DESCRIPTION
- Move upstream definition to dedicated upstream.conf.template
- Remove duplicate mime.types include from static location
- Add upstream.conf.template to Dockerfile copy commands

This change reduces duplicate configuration and improves maintainability by isolating the upstream server definition. It also eliminates duplicate mime type warnings in nginx logs.