### PR TITLE
feat: enable HTTPS server configuration

### DIFF
--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -20,54 +20,54 @@ server {
     }
 }
 
-# HTTPS server (commented out during initial setup)
-#server {
-#    listen 443 ssl;
-#    listen [::]:443 ssl;
-#    server_name ${DOMAIN};
-#    server_tokens off;
-#
-#    # SSL configuration
-#    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-#    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-#
-#    # SSL parameters
-#    ssl_protocols TLSv1.2 TLSv1.3;
-#    ssl_prefer_server_ciphers on;
-#    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-#    
-#    # SSL session handling
-#    ssl_session_timeout 1d;
-#    ssl_session_cache shared:SSL:50m;
-#    ssl_session_tickets off;
-#
-#    # Security headers
-#    add_header X-Content-Type-Options nosniff;
-#    add_header X-Frame-Options DENY;
-#    add_header X-XSS-Protection "1; mode=block";
-#    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-#    add_header Content-Security-Policy "default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval';" always;
-#    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-#
-#    client_max_body_size 20M;
-#
-#    location / {
-#        proxy_pass http://only-paws-app;
-#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#        proxy_set_header Host $host;
-#        proxy_redirect off;
-#        proxy_set_header X-Real-IP $remote_addr;
-#    }
-#
-#    location /static/ {
-#        alias /vol/web/static/;
-#        expires 1y;
-#        add_header Cache-Control "public, no-transform";
-#    }
-#
-#    location /media/ {
-#        alias /vol/web/media/;
-#        expires 7d;
-#        add_header Cache-Control "public, no-transform";
-#    }
-#} 
+# HTTPS server
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name ${DOMAIN};
+    server_tokens off;
+
+    # SSL configuration
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    # SSL parameters
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    
+    # SSL session handling
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Security headers
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'self' https: data: 'unsafe-inline' 'unsafe-eval';" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    client_max_body_size 20M;
+
+    location / {
+        proxy_pass http://only-paws-app;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /static/ {
+        alias /vol/web/static/;
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+
+    location /media/ {
+        alias /vol/web/media/;
+        expires 7d;
+        add_header Cache-Control "public, no-transform";
+    }
+} 


### PR DESCRIPTION
- Uncomment HTTPS server block in nginx.conf.template
- Remove commented version of the configuration
- Enable SSL with proper certificate paths and security headers

This change enables HTTPS support after successful SSL certificate acquisition, allowing secure connections to the API.