### PR TITLE
fix: consolidate upstream configuration (nginx)

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -11,7 +11,6 @@ RUN chmod -R 755 /vol/web
 # Copy both templates
 COPY ./templates/nginx.conf.template /etc/nginx/templates/
 COPY ./templates/init.conf.template /etc/nginx/templates/
-COPY ./templates/upstream.conf.template /etc/nginx/templates/
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 # Make the entrypoint script executable

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,5 +1,19 @@
+# Load configuration files
+include /etc/nginx/conf.d/*.conf;
+
 # prevent css, js files sent as text/plain objects
 include /etc/nginx/mime.types;
+
+# Define upstream
+upstream only-paws-app {
+    server only-paws-app:8000;
+}
+
+# Connection upgrade mapping
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
 
 # HTTP server
 server {
@@ -31,6 +45,12 @@ server {
     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
 
+    # SSL optimization
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
+
     # SSL parameters
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
@@ -51,36 +71,44 @@ server {
 
     client_max_body_size 20M;
 
-    location / {
-        proxy_pass http://only-paws-app;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
+    # CORS headers at server level
+    add_header 'Access-Control-Allow-Origin' '*' always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
 
-        # Add CORS headers
-        add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
-
-        # Better error handling
-        proxy_intercept_errors on;
-        error_page 502 = @backend_down;
-
-        # Add timeouts
-        proxy_connect_timeout 300;
-        proxy_send_timeout 300;
-        proxy_read_timeout 300;
-        send_timeout 300;
-
-        # Add error logging
-        error_log /var/log/nginx/app_error.log debug;
+    # Error handling
+    error_page 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+        internal;
     }
 
-    location @backend_down {
-        return 502 '{"error": "Backend service unavailable"}';
-        add_header Content-Type application/json;
+    location / {
+        proxy_pass http://only-paws-app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Forwarded-Port $server_port;
+
+        # Debug logging
+        access_log /var/log/nginx/app_access.log;
+        error_log /var/log/nginx/app_error.log debug;
+
+        # More reasonable timeouts
+        proxy_connect_timeout 60;
+        proxy_send_timeout 60;
+        proxy_read_timeout 60;
+        send_timeout 60;
+
+        # Buffer settings
+        proxy_buffer_size 128k;
+        proxy_buffers 4 256k;
+        proxy_busy_buffers_size 256k;
     }
 
     location /static/ {

--- a/nginx/templates/upstream.conf.template
+++ b/nginx/templates/upstream.conf.template
@@ -1,3 +1,0 @@
-upstream only-paws-app {
-    server only-paws-app:8000;
-} 


### PR DESCRIPTION
- Move upstream definition into main nginx.conf.template
- Remove separate upstream.conf.template file
- Remove upstream.conf.template from Dockerfile

This change ensures the upstream is defined in the correct context before it's used, fixing the ERR_INVALID_RESPONSE error when accessing the Django admin interface.