### PR TITLE
feat: add onlypawsapp.com to trusted origins

### DIFF
--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -49,6 +49,12 @@ CORS_ALLOW_HEADERS = [
 CSRF_TRUSTED_ORIGINS = [
     "https://api-staging.onlypawsapp.com",
     "https://api.onlypawsapp.com",
+    "https://onlypawsapp.com",
+]
+CSRF_ALLOWED_ORIGINS = [
+    "https://api-staging.onlypawsapp.com",
+    "https://api.onlypawsapp.com",
+    "https://onlypawsapp.com",
 ]
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
- Add onlypawsapp.com to CSRF_TRUSTED_ORIGINS
- Add CSRF_ALLOWED_ORIGINS with same domains
- Support cross-origin CSRF validation for main domain

This allows the main website domain to make authenticated requests to the API while maintaining CSRF protection.