### PR TITLE
feat: add protected-mode no to Redis

### DIFF
--- a/docker/dev/docker-compose.override.yml
+++ b/docker/dev/docker-compose.override.yml
@@ -84,10 +84,6 @@ services:
     command: python -m celery -A core beat -l info
     restart: unless-stopped
 
-  # Redis service configuration specific to dev
-  redis:
-    command: redis-server --appendonly yes --bind 127.0.0.1
-
 volumes:
   only-paws-db-data-dev:
   celery_beat_schedule:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     container_name: onlypaws_redis
     image: redis:7-alpine
     restart: unless-stopped
-    command: redis-server --appendonly yes --bind 127.0.0.1
+    command: redis-server --appendonly yes --bind 0.0.0.0 --protected-mode no
     volumes:
       - redis_data:/data
 

--- a/docker/prod/docker-compose.override.yml
+++ b/docker/prod/docker-compose.override.yml
@@ -24,9 +24,6 @@ services:
     env_file:
       - prod/.env.prod.db
 
-  redis:
-    command: redis-server --appendonly yes --bind 127.0.0.1
-
   nginx:
     build: ../nginx
     volumes:

--- a/docker/staging/docker-compose.override.yml
+++ b/docker/staging/docker-compose.override.yml
@@ -24,9 +24,6 @@ services:
     env_file:
       - staging/.env.staging.db
 
-  redis:
-    command: redis-server --appendonly yes --bind 127.0.0.1
-
   nginx:
     build: ../nginx
     volumes:


### PR DESCRIPTION
- Configure Redis with --bind 0.0.0.0 --protected-mode no for Docker network
- With Redis port mapping (6379:6379) removed, public internet access is prevented
- Clean up duplicate Redis configurations across override files

Resolves Redis security vulnerability identified by Digital Ocean network scan. Redis is now only accessible within the Docker container network while maintaining full functionality for Django and Celery services.