### PR TITLE
feat: migrate email sending to async Celery tasks

### DIFF
--- a/api/apps/user_app/tasks.py
+++ b/api/apps/user_app/tasks.py
@@ -1,0 +1,172 @@
+"""
+Celery tasks for the user_app.
+"""
+
+import logging
+from celery import shared_task
+from django.core.mail import send_mail
+from django.conf import settings
+from django.core.validators import validate_email
+from django.core.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3)
+def send_verification_email_task(self, user_email: str, token: str):
+    """
+    Background task to send verification email to user.
+    
+    Args:
+        user_email: User's email address
+        token: Verification token
+    """
+    try:
+        # Validate email address
+        validate_email(user_email)
+        
+        subject = "Verify Your OnlyPaws Email"
+        message = f"Your verification code is: {token}"
+        
+        send_mail(
+            subject,
+            message,
+            settings.DEFAULT_FROM_EMAIL,
+            [user_email],
+            fail_silently=False,
+        )
+        
+        logger.info(f"Verification email sent successfully to {user_email}")
+        
+    except ValidationError:
+        logger.error(f"Invalid email address: {user_email}")
+        raise  # Don't retry for invalid emails
+        
+    except Exception as exc:
+        logger.error(f"Error sending verification email to {user_email}: {str(exc)}")
+        
+        # Retry with exponential backoff
+        retry_delay = 30 * (2 ** self.request.retries)  # 30s, 60s, 120s
+        raise self.retry(exc=exc, countdown=retry_delay)
+
+
+@shared_task(bind=True, max_retries=3)
+def send_reset_password_email_task(self, user_email: str, token: str):
+    """
+    Background task to send reset password email to user.
+    
+    Args:
+        user_email: User's email address
+        token: Reset password token
+    """
+    try:
+        # Validate email address
+        validate_email(user_email)
+        
+        subject = "Reset Your OnlyPaws Password"
+        message = f"Your password reset code is: {token}"
+        
+        send_mail(
+            subject,
+            message,
+            settings.DEFAULT_FROM_EMAIL,
+            [user_email],
+            fail_silently=False,
+        )
+        
+        logger.info(f"Password reset email sent successfully to {user_email}")
+        
+    except ValidationError:
+        logger.error(f"Invalid email address: {user_email}")
+        raise  # Don't retry for invalid emails
+        
+    except Exception as exc:
+        logger.error(f"Error sending password reset email to {user_email}: {str(exc)}")
+        
+        # Retry with exponential backoff
+        retry_delay = 30 * (2 ** self.request.retries)  # 30s, 60s, 120s
+        raise self.retry(exc=exc, countdown=retry_delay)
+
+
+@shared_task(bind=True, max_retries=3)
+def send_email_change_email_task(self, new_email: str, token: str):
+    """
+    Background task to send email change verification email.
+    
+    Args:
+        new_email: New email address to send verification to
+        token: Email change verification token
+    """
+    try:
+        # Validate email address
+        validate_email(new_email)
+        
+        subject = "Update Your OnlyPaws Email"
+        message = f"Your email update code is: {token}"
+        
+        send_mail(
+            subject,
+            message,
+            settings.DEFAULT_FROM_EMAIL,
+            [new_email],
+            fail_silently=False,
+        )
+        
+        logger.info(f"Email change verification sent successfully to {new_email}")
+        
+    except ValidationError:
+        logger.error(f"Invalid email address: {new_email}")
+        raise  # Don't retry for invalid emails
+        
+    except Exception as exc:
+        logger.error(f"Error sending email change verification to {new_email}: {str(exc)}")
+        
+        # Retry with exponential backoff
+        retry_delay = 30 * (2 ** self.request.retries)  # 30s, 60s, 120s
+        raise self.retry(exc=exc, countdown=retry_delay)
+
+
+@shared_task(bind=True, max_retries=3)
+def send_email_change_confirmation_task(self, old_email: str, new_email: str):
+    """
+    Background task to send confirmation emails after successful email change.
+    
+    Args:
+        old_email: Previous email address
+        new_email: New email address
+    """
+    try:
+        # Validate email addresses
+        validate_email(old_email)
+        validate_email(new_email)
+        
+        # Send confirmation to new email
+        send_mail(
+            "Email change successful",
+            "Your email has been successfully updated.",
+            settings.DEFAULT_FROM_EMAIL,
+            [new_email],
+            fail_silently=False,
+        )
+        
+        # Send notification to old email
+        send_mail(
+            "Your email has been changed",
+            f"Your email has been changed to {new_email}.",
+            settings.DEFAULT_FROM_EMAIL,
+            [old_email],
+            fail_silently=False,
+        )
+        
+        logger.info(f"Email change confirmation sent to both {old_email} and {new_email}")
+        
+    except ValidationError as e:
+        logger.error(f"Invalid email address in confirmation task: {str(e)}")
+        raise  # Don't retry for invalid emails
+        
+    except Exception as exc:
+        logger.error(f"Error sending email change confirmation: {str(exc)}")
+        
+        # Retry with exponential backoff
+        retry_delay = 30 * (2 ** self.request.retries)  # 30s, 60s, 120s
+        raise self.retry(exc=exc, countdown=retry_delay)

--- a/api/apps/user_app/views.py
+++ b/api/apps/user_app/views.py
@@ -15,6 +15,12 @@ from apps.core_app.models import (
 )
 from apps.core_app.utils import generate_verification_code
 from rest_framework import serializers
+from .tasks import (
+    send_verification_email_task,
+    send_reset_password_email_task,
+    send_email_change_email_task,
+    send_email_change_confirmation_task,
+)
 from .serializers import (
     UserSerializer,
     ProfileDetailedSerializer,
@@ -30,7 +36,6 @@ from .serializers import (
 )
 from rest_framework.response import Response
 import logging
-from django.core.mail import send_mail
 from django.utils import timezone
 from django.db import transaction
 from datetime import timedelta
@@ -39,7 +44,6 @@ from drf_spectacular.utils import (
     extend_schema,
     OpenApiParameter,
 )
-from django.conf import settings
 from rest_framework.views import APIView
 from django.contrib.auth import authenticate
 from django.core.validators import validate_email
@@ -59,44 +63,36 @@ auth_profile_param = OpenApiParameter(
 logger = logging.getLogger(__file__)
 
 
-# helper function to send verification email
-def send_verification_email(user, token):
-    """Send verification email to user."""
-    subject = "Verify Your OnlyPaws Email"
-    message = f"Your verification code is: {token}"
-    send_mail(
-        subject,
-        message,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email],
-        fail_silently=False,
-    )
+# Email sending is now handled by async tasks
+# These functions are kept for backward compatibility but now queue tasks
+def send_verification_email(user, token_string):
+    """Queue verification email task for user.
+    
+    Args:
+        user: User object
+        token_string: String token (not VerifyEmailToken object)
+    """
+    send_verification_email_task.delay(user.email, token_string)
 
 
-def send_reset_password_email(user, token):
-    """Send reset password email to user."""
-    subject = "Reset Your OnlyPaws Password"
-    message = f"Your password reset code is: {token}"
-    send_mail(
-        subject,
-        message,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email],
-        fail_silently=False,
-    )
+def send_reset_password_email(user, token_string):
+    """Queue reset password email task for user.
+    
+    Args:
+        user: User object
+        token_string: String token (not ResetPasswordToken object)
+    """
+    send_reset_password_email_task.delay(user.email, token_string)
 
 
-def send_reset_email_email(email, token):
-    """Send change email email to user."""
-    subject = "Update Your OnlyPaws Email"
-    message = f"Your email update code is: {token}"
-    send_mail(
-        subject,
-        message,
-        settings.DEFAULT_FROM_EMAIL,
-        [email],
-        fail_silently=True,
-    )
+def send_reset_email_email(email, token_string):
+    """Queue email change verification task.
+    
+    Args:
+        email: Email address string
+        token_string: String token (not verification token object)
+    """
+    send_email_change_email_task.delay(email, token_string)
 
 
 class CreateUserView(generics.CreateAPIView):
@@ -146,12 +142,12 @@ class CreateUserView(generics.CreateAPIView):
                 verify_email_serializer.is_valid(raise_exception=True)
                 self.perform_create(verify_email_serializer)
 
-                token = VerifyEmailToken.objects.get(
+                verify_token_obj = VerifyEmailToken.objects.get(
                     id=verify_email_serializer.data["id"]
                 )
 
-                # send email with token
-                send_verification_email(user, token)
+                # send email with token string
+                send_verification_email(user, verify_token_obj.token)
 
                 response_serializer = UserProfileSerializer(user)
 
@@ -810,28 +806,8 @@ class VerifyEmailChangeView(APIView):
         # Delete pending change
         pending_change.delete()
 
-        # Send confirmation emails
-        try:
-            # Notify new email
-            send_mail(
-                "Email change successful",
-                "Your email has been successfully updated.",
-                settings.DEFAULT_FROM_EMAIL,
-                [new_email],
-                fail_silently=True,
-            )
-
-            # Notify old email
-            send_mail(
-                "Your email has been changed",
-                f"Your email has been changed to {new_email}.",
-                settings.DEFAULT_FROM_EMAIL,
-                [old_email],
-                fail_silently=True,
-            )
-        except Exception:
-            # Don't fail if confirmation emails fail
-            pass
+        # Send confirmation emails asynchronously
+        send_email_change_confirmation_task.delay(old_email, new_email)
 
         return Response(
             {"message": "Email updated successfully."}, status=status.HTTP_200_OK

--- a/api/core/celery.py
+++ b/api/core/celery.py
@@ -23,9 +23,14 @@ app.autodiscover_tasks()
 app.conf.task_routes = {
     "apps.core_app.tasks.generate_image_embedding_task": {"queue": "embeddings"},
     "apps.core_app.tasks.batch_generate_embeddings_task": {"queue": "embeddings"},
+    # Email tasks go to default queue for fast processing
+    "apps.user_app.tasks.send_verification_email_task": {"queue": "default"},
+    "apps.user_app.tasks.send_reset_password_email_task": {"queue": "default"},
+    "apps.user_app.tasks.send_email_change_email_task": {"queue": "default"},
+    "apps.user_app.tasks.send_email_change_confirmation_task": {"queue": "default"},
 }
 
-# Configure worker settings for embedding tasks
+# Configure worker settings for different task types
 app.conf.task_annotations = {
     "apps.core_app.tasks.generate_image_embedding_task": {
         "rate_limit": "60/m",  # Increased to 60 tasks per minute for better user experience
@@ -36,6 +41,27 @@ app.conf.task_annotations = {
         "rate_limit": "10/m",  # Increased batch processing rate
         "time_limit": 3600,  # 1 hour timeout for batch jobs
         "soft_time_limit": 3300,  # 55 minutes soft timeout
+    },
+    # Email task settings - fast processing with reasonable timeouts
+    "apps.user_app.tasks.send_verification_email_task": {
+        "rate_limit": "100/m",  # Allow high throughput for emails
+        "time_limit": 60,  # 1 minute timeout
+        "soft_time_limit": 45,  # 45 seconds soft timeout
+    },
+    "apps.user_app.tasks.send_reset_password_email_task": {
+        "rate_limit": "100/m",
+        "time_limit": 60,
+        "soft_time_limit": 45,
+    },
+    "apps.user_app.tasks.send_email_change_email_task": {
+        "rate_limit": "100/m",
+        "time_limit": 60,
+        "soft_time_limit": 45,
+    },
+    "apps.user_app.tasks.send_email_change_confirmation_task": {
+        "rate_limit": "100/m",
+        "time_limit": 60,
+        "soft_time_limit": 45,
     },
 }
 

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -258,10 +258,6 @@ CELERY_ENABLE_UTC = True
 
 # Task routing and queue configuration
 CELERY_TASK_DEFAULT_QUEUE = "default"
-CELERY_TASK_ROUTES = {
-    "apps.core_app.tasks.generate_image_embedding_task": {"queue": "embeddings"},
-    "apps.core_app.tasks.batch_generate_embeddings_task": {"queue": "embeddings"},
-}
 
 # Worker configuration
 CELERY_WORKER_PREFETCH_MULTIPLIER = (

--- a/api/core/settings_test.py
+++ b/api/core/settings_test.py
@@ -21,3 +21,10 @@ DATABASES = {
         "PORT": os.environ.get("DB_PORT"),
     }
 }
+
+# Celery Configuration for Tests
+# Run tasks synchronously during testing to avoid Redis dependency
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_BROKER_URL = 'memory://'
+CELERY_RESULT_BACKEND = 'cache+memory://'


### PR DESCRIPTION
- Create user_app/tasks.py with Celery tasks for all email operations:
  - send_verification_email_task
  - send_reset_password_email_task
  - send_email_change_email_task
  - send_email_change_confirmation_task
- Refactor views.py to use async task queuing instead of blocking email sends
- Configure Celery routing and rate limiting for email tasks in celery.py
- Add test-specific Celery configuration to run tasks synchronously
- Remove duplicate task routing from settings.py (moved to celery.py)

This improves API response times by offloading email sending to background workers and adds proper retry logic with exponential backoff for email delivery failures.