### PR TITLE
fix: use dedicated nginx directory for maintenance mode config

### DIFF
--- a/docs/MAINTENANCE_MODE.md
+++ b/docs/MAINTENANCE_MODE.md
@@ -280,7 +280,7 @@ curl http://localhost:8000/api/v1/config/status/
 ./scripts/maintenance-status.sh
 
 # Force remove maintenance config
-docker exec <nginx-container> rm -f /etc/nginx/conf.d/maintenance.conf
+docker exec <nginx-container> rm -f /etc/nginx/maintenance.d/maintenance.conf
 docker exec <nginx-container> nginx -s reload
 ```
 

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -46,8 +46,9 @@ server {
     client_max_body_size 20M;
 
     # Maintenance mode check - include flag
+    # Note: Using /etc/nginx/maintenance.d/ to avoid conflict with default conf.d includes
     set $maintenance_mode 0;
-    include /etc/nginx/conf.d/maintenance.conf*;
+    include /etc/nginx/maintenance.d/*.conf;
 
     # Status endpoint - ALWAYS accessible, even during maintenance
     # This provides a fallback response if Django is down

--- a/scripts/maintenance-off.sh
+++ b/scripts/maintenance-off.sh
@@ -59,7 +59,7 @@ fi
 
 # Remove the maintenance config file
 echo -e "${YELLOW}Removing maintenance flag...${NC}"
-docker exec "$CONTAINER_NAME" rm -f /etc/nginx/conf.d/maintenance.conf
+docker exec "$CONTAINER_NAME" rm -f /etc/nginx/maintenance.d/maintenance.conf
 
 # Test nginx configuration
 echo -e "${YELLOW}Testing nginx configuration...${NC}"

--- a/scripts/maintenance-on.sh
+++ b/scripts/maintenance-on.sh
@@ -73,8 +73,9 @@ fi
 MAINTENANCE_CONFIG="set \$maintenance_mode 1;"
 
 # Create the maintenance config file inside the container
+# Using /etc/nginx/maintenance.d/ to avoid conflict with default conf.d includes at http level
 echo -e "${YELLOW}Creating maintenance flag...${NC}"
-docker exec "$CONTAINER_NAME" sh -c "echo '$MAINTENANCE_CONFIG' > /etc/nginx/conf.d/maintenance.conf"
+docker exec "$CONTAINER_NAME" sh -c "mkdir -p /etc/nginx/maintenance.d && echo '$MAINTENANCE_CONFIG' > /etc/nginx/maintenance.d/maintenance.conf"
 
 # Test nginx configuration
 echo -e "${YELLOW}Testing nginx configuration...${NC}"
@@ -93,6 +94,6 @@ if docker exec "$CONTAINER_NAME" nginx -t 2>&1; then
 else
     echo -e "${RED}Error: nginx configuration test failed${NC}"
     # Remove the invalid config
-    docker exec "$CONTAINER_NAME" rm -f /etc/nginx/conf.d/maintenance.conf
+    docker exec "$CONTAINER_NAME" rm -f /etc/nginx/maintenance.d/maintenance.conf
     exit 1
 fi

--- a/scripts/maintenance-status.sh
+++ b/scripts/maintenance-status.sh
@@ -58,11 +58,11 @@ fi
 echo -e "nginx container: ${GREEN}$CONTAINER_NAME${NC}"
 
 # Check if maintenance config file exists
-if docker exec "$CONTAINER_NAME" test -f /etc/nginx/conf.d/maintenance.conf 2>/dev/null; then
+if docker exec "$CONTAINER_NAME" test -f /etc/nginx/maintenance.d/maintenance.conf 2>/dev/null; then
     echo -e "Maintenance mode: ${YELLOW}ENABLED${NC}"
     echo ""
     echo "Maintenance config:"
-    docker exec "$CONTAINER_NAME" cat /etc/nginx/conf.d/maintenance.conf
+    docker exec "$CONTAINER_NAME" cat /etc/nginx/maintenance.d/maintenance.conf
 else
     echo -e "Maintenance mode: ${GREEN}DISABLED${NC}"
     echo "System is operational"


### PR DESCRIPTION
The default nginx.conf includes /etc/nginx/conf.d/*.conf at the http level where 'set' directives are not allowed. Changed to use /etc/nginx/maintenance.d/ which is only included inside the server block in our custom config.