### PR TITLE
fix: remove duplicate mime.types include causing nginx warnings

### DIFF
--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,6 +1,3 @@
-# prevent css, js files sent as text/plain objects
-include /etc/nginx/mime.types;
-
 # Define upstream
 upstream only-paws-app {
     server only-paws-app:8000;


### PR DESCRIPTION
The main nginx.conf already includes mime.types at the http level. Including it again in the conf.d template caused duplicate extension warnings during nginx -t and reload operations.